### PR TITLE
ci: fix link checker

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -23,3 +23,4 @@ jobs:
           use-quiet-mode: 'yes'
           use-verbose-mode: 'yes'
           max-depth: 0
+          config-file: ".mlc_config.json"

--- a/.mlc_config.json
+++ b/.mlc_config.json
@@ -1,0 +1,29 @@
+{
+  "aliveStatusCodes": [
+    403,
+    200,
+    206
+  ],
+  "httpHeaders": [
+    {
+      "urls": [
+        "https://github.com/",
+        "https://guides.github.com/",
+        "https://help.github.com/",
+        "https://docs.github.com/"
+      ],
+      "headers": {
+        "Accept-Encoding": "zstd, br, gzip, deflate"
+      }
+    }
+  ],
+  "retryOn429": true,
+  "ignorePatterns": [
+    {
+      "pattern": "/github/workspace/.*"
+    },
+    {
+      "pattern": "crates.io"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a config .mlc_config.json to the root dir.
This enables us to filter patterns such as crates.io. I took the liberty of adding additional configs that I  am using in other repos that depend on markdown-link-check CI action.

Closes #8.