### PR TITLE
Update book link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Book of BDK
 
-This repository hosts the code and content for the [Book of BDK website](https://thunderbiscuit.github.io/book-of-bdk/).
+This repository hosts the code and content for the [Book of BDK website](https://bitcoindevkit.github.io/book-of-bdk/).
 We use [`mkdocs-material`](https://squidfunk.github.io/mkdocs-material) to render the website and the content.
 
 ## Develop locally


### PR DESCRIPTION
Quick update to the book link in the README. IT was pointing to https://thunderbiscuit.github.io/book-of-bdk/ instead of https://bitcoindevkit.github.io/book-of-bdk/. Feel free to close if this is intentional. 