### PR TITLE
Add page: Who Is This Book For?

### DIFF
--- a/docs/getting-started/why-book.md
+++ b/docs/getting-started/why-book.md
@@ -1,0 +1,11 @@
+# Who Is This Book For?
+
+The purpose of this book is to give a strong overview of the Bitcoin Development Kit family of libraries and how they can be used together to build production-grade bitcoin applications. We aim to provide a good understanding of how to leverage our libraries together, expose the options available to developers in terms of blockchain clients and persistence layers, as well as ways they can go deeper into lower-level crates if their needs are not met by the high-level APIs exposed in the `bdk_wallet` library.
+
+Finally, the book is meant to get developers up to speed on general concepts pertaining to the BDK architecture as well as concrete examples of how to use our APIs in the different languages for which we provide language bindings libraries.
+
+**What this book is not:**
+
+- API documentation, nor a comprehensive listing of all APIs available in BDK libraries. We maintain [API docs](./api-documentation.md) on all our libraries for that purpose.
+- A place to learn about core bitcoin concepts (PSBTs, UTXOs, Electrum protocol, BIPs, etc.). We provide links to great resources on these topics where appropriate.
+- A comprehensive treatment of the tradeoff space developers face when building bitcoin applications (Esplora protocol vs compact block filters, onchain vs layer 2s, secure elements on mobile devices, etc.).

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,4 +1,4 @@
-# Book of BDK
+# The Bitcoin Development Kit
 
 The Bitcoin Development Kit (BDK) project was created to provide well engineered and reviewed components for building bitcoin-based applications.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,7 +73,8 @@ markdown_extensions:
 
 nav:
   - Getting Started: 
-    - About: index.md
+    - About BDK: index.md
+    - Why this Book?: getting-started/why-book.md
     - Project Organization: getting-started/organization.md
     - Getting Started: getting-started/getting-started.md
     - API Documentation: getting-started/api-documentation.md


### PR DESCRIPTION
This page outlines the why and the who as well as current scope for the book.

I do think that in the long run, this scope can be expanded to include sections that would potentially cover points 2 and 3 listed in the "What this book is not" section, but in the short term and to keep in line with the 1.0 release timeline this sets the tone. We're working on the "how to" use BDK, not the why or the what just yet.
