### PR TITLE
Add Rust CI workflow to run quickstart example

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,23 @@
+name: Run Examples
+on: [push, pull_request, workflow_dispatch]
+
+jobs:
+  run-examples:
+    name: "Build and run Rust examples"
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: examples/rust/
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+
+      - name: "Set default toolchain"
+        run: rustup default 1.77.1
+
+      - name: "Build + run quickstart example"
+        run: |
+          cd quickstart
+          cargo build
+          cargo run


### PR DESCRIPTION
This PR brings in a CI workflow that builds and runs the quickstart Rust example.

We can expand on this as time goes and add more examples; this is an MVP of the workflow. You can see that it succeeds on `master` [here](https://github.com/thunderbiscuit/book-of-bdk/actions/runs/11460899114).