### PR TITLE
Update `bdk_kyoto` to latest version

### DIFF
--- a/examples/rust/syncing/kyoto/Cargo.toml
+++ b/examples/rust/syncing/kyoto/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_kyoto = { version = "0.6.0", default-features = false, features = ["rusqlite", "wallet", "callbacks"] }
-bdk_wallet = { version = "1.0.0" }
+bdk_kyoto = "0.7.0"
+bdk_wallet = "1.0.0"
 tokio = { version = "1.37", features = ["full"], default-features = false }
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/examples/rust/syncing/kyoto/src/main.rs
+++ b/examples/rust/syncing/kyoto/src/main.rs
@@ -1,8 +1,8 @@
 use bdk_kyoto::builder::LightClientBuilder;
-use bdk_kyoto::logger::PrintLogger;
-use bdk_kyoto::LightClient;
+use bdk_kyoto::{LightClient, LogSubscriber, WarningSubscriber};
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::{KeychainKind, Wallet};
+use tokio::select;
 
 const RECEIVE: &str = "tr([7d94197e/86'/1'/0']tpubDCyQVJj8KzjiQsFjmb3KwECVXPvMwvAxxZGCP9XmWSopmjW3bCV3wD7TgxrUhiGSueDS1MU5X1Vb1YjYcp8jitXc5fXfdC1z68hDDEyKRNr/0/*)";
 const CHANGE: &str = "tr([7d94197e/86'/1'/0']tpubDCyQVJj8KzjiQsFjmb3KwECVXPvMwvAxxZGCP9XmWSopmjW3bCV3wD7TgxrUhiGSueDS1MU5X1Vb1YjYcp8jitXc5fXfdC1z68hDDEyKRNr/1/*)";
@@ -10,8 +10,26 @@ const RECOVERY_HEIGHT: u32 = 190_000;
 const RECOVERY_LOOKAHEAD: u32 = 50;
 const NUM_CONNECTIONS: u8 = 1;
 
+/// Implement a custom logger that prints log messages to the console.
+async fn trace_logs(mut log_subscriber: LogSubscriber, mut warning_subscriber: WarningSubscriber) {
+    loop {
+        select! {
+            log = log_subscriber.next_log() => {
+                tracing::info!("{log}")
+            }
+            warn = warning_subscriber.next_warning() => {
+                tracing::warn!("{warn}")
+            }
+        }
+    }
+}
+
 #[tokio::main]
 async fn main() {
+    // Initialize tracing
+    let subscriber = tracing_subscriber::FmtSubscriber::new();
+    tracing::subscriber::set_global_default(subscriber).unwrap();
+
     // Apply the recovery lookahead to the wallet
     let mut wallet = Wallet::create(RECEIVE, CHANGE)
         .network(Network::Signet)
@@ -23,8 +41,10 @@ async fn main() {
     // In addition, receive a client that allows for communication with a running node to receive wallet
     // updates, relay transactions to the node, and get updates on the node's actions.
     let LightClient {
-        sender,
-        mut receiver,
+        requester,
+        log_subscriber,
+        warning_subscriber,
+        mut update_subscriber,
         node,
     } = LightClientBuilder::new()
         .scan_after(RECOVERY_HEIGHT)
@@ -37,30 +57,27 @@ async fn main() {
     // as the application is running.
     tokio::task::spawn(async move { node.run().await });
 
-    // Print logs to the console.
-    let logger = PrintLogger::new();
+    // Trace the logs with a custom function.
+    tokio::task::spawn(async move { trace_logs(log_subscriber, warning_subscriber).await });
 
     // Sync and apply updates to the wallet. We can do this a continual loop while the application is running.
     // Often this would occur on a separate thread than the underlying application user interface.
     loop {
-        // Wait for an update from the client, if there is one. Intermediate logs and warnings
-        // are handled by the `PrintLogger`. Note that `PrintLogger` implements `NodeEventHandler`.
-        // A production application would likely implement custom behavior by implementing
-        // a novel `NodeEventHandler`.
-        if let Some(update) = receiver.update(&logger).await {
+        // Wait for an update from the client, if there is one.
+        if let Some(update) = update_subscriber.update().await {
             wallet.apply_update(update).unwrap();
-            println!("Tx count: {}", wallet.transactions().count());
-            println!("Balance: {}", wallet.balance().total().to_sat());
+            tracing::info!("Tx count: {}", wallet.transactions().count());
+            tracing::info!("Balance: {}", wallet.balance().total().to_sat());
             let last_revealed = wallet.derivation_index(KeychainKind::External).unwrap();
-            println!("Last revealed External: {}", last_revealed);
-            println!(
+            tracing::info!("Last revealed External: {}", last_revealed);
+            tracing::info!(
                 "Last revealed Internal: {}",
                 wallet.derivation_index(KeychainKind::Internal).unwrap()
             );
-            println!("Local chain tip: {}", wallet.local_chain().tip().height());
+            tracing::info!("Local chain tip: {}", wallet.local_chain().tip().height());
             let next = wallet.peek_address(KeychainKind::External, last_revealed + 1);
-            println!("Next receiving address: {next}");
-            sender.add_script(next.address).await.unwrap();
+            tracing::info!("Next receiving address: {next}");
+            requester.add_script(next.address).await.unwrap();
             break;
         }
     }


### PR DESCRIPTION
Bringing in some new dependencies here because logging is no longer abstracted away from the user. Now users may interpret the messages from the node in a simple way as I demonstrated here, or in a more complex way that reflects their use case. This API removes any need for traits.