### PR TITLE
Remove architecture section

### DIFF
--- a/docs/architecture/design.md
+++ b/docs/architecture/design.md
@@ -1,3 +1,0 @@
-# Design of the BDK Ecosystem
-
-The pages in this section intend to speak to _why_ the BDK crates are designed the way they are, and the relationship between them.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -104,7 +104,3 @@ nav:
     - Transactions:
       - Transaction Builder: cookbook/transactions/transaction-builder.md
     - WASM: cookbook/wasm.md
-
-  - Architecture:
-    - Overview:
-      - Design: architecture/design.md


### PR DESCRIPTION
As discussed on the dev call. We can bring this section back in one form or another, but for now it doesn't add much as a placeholder.