### PR TITLE
Update `bdk_kyoto` to `0.9.0`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ __pycache__/
 
 # Data
 data/
+light_client_data/
 
 # Distribution / packaging
 .Python

--- a/examples/rust/syncing/kyoto/Cargo.toml
+++ b/examples/rust/syncing/kyoto/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_kyoto = "0.7.0"
-bdk_wallet = "1.0.0"
-tokio = { version = "1.37", features = ["full"], default-features = false }
+bdk_kyoto = "0.9.0"
+bdk_wallet = "1"
+tokio = { version = "1", features = ["full"], default-features = false }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/examples/rust/syncing/kyoto/src/main.rs
+++ b/examples/rust/syncing/kyoto/src/main.rs
@@ -1,5 +1,5 @@
-use bdk_kyoto::builder::LightClientBuilder;
-use bdk_kyoto::{LightClient, LogSubscriber, WarningSubscriber};
+use bdk_kyoto::builder::{NodeBuilder, NodeBuilderExt};
+use bdk_kyoto::{Info, LightClient, Receiver, ScanType, UnboundedReceiver, Warning};
 use bdk_wallet::bitcoin::Network;
 use bdk_wallet::{KeychainKind, Wallet};
 use tokio::select;
@@ -9,16 +9,30 @@ const CHANGE: &str = "tr([7d94197e/86'/1'/0']tpubDCyQVJj8KzjiQsFjmb3KwECVXPvMwvA
 const RECOVERY_HEIGHT: u32 = 190_000;
 const RECOVERY_LOOKAHEAD: u32 = 50;
 const NUM_CONNECTIONS: u8 = 1;
+const NETWORK: Network = Network::Signet;
 
 /// Implement a custom logger that prints log messages to the console.
-async fn trace_logs(mut log_subscriber: LogSubscriber, mut warning_subscriber: WarningSubscriber) {
+async fn trace_logs(
+    mut log_rx: Receiver<String>,
+    mut info_rx: Receiver<Info>,
+    mut warn_rx: UnboundedReceiver<Warning>,
+) {
     loop {
         select! {
-            log = log_subscriber.next_log() => {
-                tracing::info!("{log}")
+            log = log_rx.recv() => {
+                if let Some(log) = log {
+                    tracing::info!("{log}")
+                }
             }
-            warn = warning_subscriber.next_warning() => {
-                tracing::warn!("{warn}")
+            warn = warn_rx.recv() => {
+                if let Some(warn) = warn {
+                    tracing::warn!("{warn}")
+                }
+            }
+            info = info_rx.recv() => {
+                if let Some(info) = info {
+                    tracing::info!("{info}")
+                }
             }
         }
     }
@@ -32,10 +46,14 @@ async fn main() {
 
     // Apply the recovery lookahead to the wallet
     let mut wallet = Wallet::create(RECEIVE, CHANGE)
-        .network(Network::Signet)
+        .network(NETWORK)
         .lookahead(RECOVERY_LOOKAHEAD)
         .create_wallet_no_persist()
         .unwrap();
+
+    let scan_type = ScanType::Recovery {
+        from_height: RECOVERY_HEIGHT,
+    };
 
     // Build a node that will find and connect to peers, gather relevant blocks, and broadcast transactions.
     // In addition, receive a client that allows for communication with a running node to receive wallet
@@ -43,13 +61,13 @@ async fn main() {
     let LightClient {
         requester,
         log_subscriber,
+        info_subscriber,
         warning_subscriber,
         mut update_subscriber,
         node,
-    } = LightClientBuilder::new()
-        .scan_after(RECOVERY_HEIGHT)
-        .connections(NUM_CONNECTIONS)
-        .build(&wallet)
+    } = NodeBuilder::new(NETWORK)
+        .required_peers(NUM_CONNECTIONS)
+        .build_with_wallet(&wallet, scan_type)
         .unwrap();
 
     // Run the node on a separate task. The node will run continuously until instructed by the client
@@ -58,27 +76,23 @@ async fn main() {
     tokio::task::spawn(async move { node.run().await });
 
     // Trace the logs with a custom function.
-    tokio::task::spawn(async move { trace_logs(log_subscriber, warning_subscriber).await });
+    tokio::task::spawn(async move {
+        trace_logs(log_subscriber, info_subscriber, warning_subscriber).await
+    });
 
     // Sync and apply updates to the wallet. We can do this a continual loop while the application is running.
     // Often this would occur on a separate thread than the underlying application user interface.
-    loop {
-        // Wait for an update from the client, if there is one.
-        if let Some(update) = update_subscriber.update().await {
-            wallet.apply_update(update).unwrap();
-            tracing::info!("Tx count: {}", wallet.transactions().count());
-            tracing::info!("Balance: {}", wallet.balance().total().to_sat());
-            let last_revealed = wallet.derivation_index(KeychainKind::External).unwrap();
-            tracing::info!("Last revealed External: {}", last_revealed);
-            tracing::info!(
-                "Last revealed Internal: {}",
-                wallet.derivation_index(KeychainKind::Internal).unwrap()
-            );
-            tracing::info!("Local chain tip: {}", wallet.local_chain().tip().height());
-            let next = wallet.peek_address(KeychainKind::External, last_revealed + 1);
-            tracing::info!("Next receiving address: {next}");
-            requester.add_script(next.address).await.unwrap();
-            break;
-        }
-    }
+    let update = update_subscriber.update().await;
+    wallet.apply_update(update).unwrap();
+    tracing::info!("Tx count: {}", wallet.transactions().count());
+    tracing::info!("Balance: {}", wallet.balance().total().to_sat());
+    let last_revealed_external = wallet.derivation_index(KeychainKind::External).unwrap_or(0);
+    tracing::info!("Last revealed External: {}", last_revealed_external);
+    let last_revealed_internal = wallet.derivation_index(KeychainKind::Internal).unwrap_or(0);
+    tracing::info!("Last revealed Internal: {}", last_revealed_internal);
+    tracing::info!("Local chain tip: {}", wallet.local_chain().tip().height());
+    let next = wallet.peek_address(KeychainKind::External, last_revealed_external + 1);
+    tracing::info!("Next receiving address: {next}");
+    requester.add_script(next.address).unwrap();
+    requester.shutdown().unwrap();
 }


### PR DESCRIPTION
Change summary: Debug strings and info messages are separated into their own channels now. The `LogSubscriber` and `WarningSubscriber` are removed because `tokio` channels are more performant. The `NodeBuilder` is exposed directly from `kyoto` and `bdk_kyoto` offers an extension trait to build for a `Wallet`. This allows `bdk_kyoto` users to configure the `kyoto` node in full, but take full advantage of the shortcuts within `bdk_kyoto`