### PR TITLE
Update `bdk_wallet` and `kyoto`

### DIFF
--- a/examples/rust/syncing/kyoto/Cargo.toml
+++ b/examples/rust/syncing/kyoto/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "kyoto"
+name = "kyoto-example"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bdk_kyoto = "0.9.0"
-bdk_wallet = "1"
+bdk_kyoto = "0.12.0"
+bdk_wallet = "2"
 tokio = { version = "1", features = ["full"], default-features = false }
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/examples/rust/syncing/kyoto/src/main.rs
+++ b/examples/rust/syncing/kyoto/src/main.rs
@@ -82,7 +82,7 @@ async fn main() {
 
     // Sync and apply updates to the wallet. We can do this a continual loop while the application is running.
     // Often this would occur on a separate thread than the underlying application user interface.
-    let update = update_subscriber.update().await;
+    let update = update_subscriber.update().await.unwrap();
     wallet.apply_update(update).unwrap();
     tracing::info!("Tx count: {}", wallet.transactions().count());
     tracing::info!("Balance: {}", wallet.balance().total().to_sat());


### PR DESCRIPTION
Preparation to update Kyoto syncing example to `bdk_wallet` version `2.0.0`