### PR TITLE
Remove outdated warning

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,9 +6,6 @@ The core components of BDK are written in the [Rust] language and live in the [`
 
 The BDK team also maintains the [`bitcoindevkit/bdk-ffi`][bitcoindevkit/bdk-ffi] repository which provide cross-platform versions of the high level BDK APIs. Platforms currently supported by the BDK team include: [Kotlin] (Android, Linux, macOS), [Swift] (iOS, macOS), and [Python] (Linux, macOS, Windows). There are also various [3rd party supported bindings for other languages](./getting-started/3rd-party-bindings.md), including Flutter, ReactNative, and JavaScript (WASM bindings for Browser/Node/ReactNative).
 
-!!! warning
-    The [`bitcoindevkit/bdk-ffi`][bitcoindevkit/bdk-ffi] project has not yet been updated to use the new `BDK 1.0` crates. For current status and timeline for bdk-ffi, see the [`bdk-ffi`][bitcoindevkit/bdk-ffi] project repository.
-
 [bitcoindevkit/bdk]: https://github.com/bitcoindevkit/bdk
 [rust-bitcoin]: https://github.com/rust-bitcoin/rust-bitcoin
 [rust-miniscript]: https://github.com/rust-bitcoin/rust-miniscript


### PR DESCRIPTION
BDK FFI is on 1.2 and will be soon on 2.0.0 of `bdk_wallet`