### PR TITLE
Add BDK Tech Talks links to More BDK Content page

### DIFF
--- a/docs/getting-started/more.md
+++ b/docs/getting-started/more.md
@@ -1,23 +1,29 @@
 # More Places to Find BDK Content
-
 Here are some other places you can find BDK-related content:
-
 ## Youtube
-
 - We have [our own YouTube channel](https://www.youtube.com/@bitcoindevkit)!
-- Check out the [BDK Tech Talks](https://www.youtube.com/playlist?list=PLFQTgyPgNM1iP9vqO6-Oic02x-MhxrNQu) series for in-depth talks about BDK.
 - [Building on bitcoin with the Bitcoin Development Kit (BitDevsLA)](https://youtu.be/ydfrRl5n5-8?si=vB8y6k3iZlakxEvL)
 - The _Bitcoin Developers_ channel has a [series of videos on BDK](https://www.youtube.com/playlist?list=PLmyfVqsSelG0h2PQwcHZFsxBy2VsPZLFn).
 - [Building on BDK with Ben Carman, Alekos Filini & Steve Myers](https://www.youtube.com/watch?v=Qlbwxbe7xHE)
 - [Using the Bitcoin Development Kit and Wallet Descriptors for Taproot](https://youtu.be/wsQIZRY2BD0?si=FPkRUaHCnD64lqV-)
 - [User Research on FOSS bitcoin project: Bitcoin Dev Kit](https://youtu.be/BjeDZC59tiM?si=tkMRISmP6ho5d32_)
 - [Building wallets with Rust using Bitcoin](https://youtube.com/playlist?list=PL38rDfx7QwKYsDUvKcjd72QbN8LRfa1QI&si=nUzqx08erkHcBx-1) (basic tutorial series)
-- [Magical Bitcoin (now BDK) presentation by Alekos Filini (BitDevsLA)](https://youtu.be/QVhC2DOIl7I?si=Z_CAMUC1FGBEA8hN) 
+- [Magical Bitcoin (now BDK) presentation by Alekos Filini (BitDevsLA)](https://youtu.be/QVhC2DOIl7I?si=Z_CAMUC1FGBEA8hN)
+- Check out the [BDK Tech Talks](https://www.youtube.com/playlist?list=PLFQTgyPgNM1iP9vqO6-Oic02x-MhxrNQu) series for in-depth talks about BDK.
+
+**BDK Technical Talks Series**
+
+| Talk | Speaker |
+|------|---------|
+| [BDK Language Bindings](https://youtu.be/XGZNeXLsZeU?si=eejsdz-wZM4sh4J-) | thunderbiscuit |
+| [BDK Silent Payments](https://youtu.be/rZiGyNoxcGw?si=uFuhaFZyDn35hqoV) | nymius |
+| [Getting Your Transaction in Order](https://youtu.be/dd2VX19q6go?si=uu2qYX2B27eXfFCe) | ValuedMammal |
+| [BDK-CLI](https://youtu.be/Jr2OVCEe9JM?si=MJAl7J4mLME5bwwd) | Peter Tyonum |
+| [Integrating Compact Block Filters in Wallets](https://youtu.be/_sLJSC5Ixh4?si=hgtrQA9jABNtWkvU) | Robert Netzke |
+| [BDK on Mobile](https://youtu.be/J2wLCv_fx5Y?si=7_YKAxhFFZdcnqbZ) | Matthew Ramsden |
+| [BDK at Portal](https://youtu.be/koaeRIpXUZM?si=WbST3-VKOoYf29Oy) | Alekos Filini |
 
 ## Podcasts
-
 - [Alekos and Daniela on the Chaincode Podcast](https://podcast.chaincode.com/2023/05/25/bdk-alekos-daniela)
-
 ## Awesome List
-
 - We maintain an [Awesome List](https://github.com/bitcoindevkit/awesome-bdk) for BDK.


### PR DESCRIPTION
Closes #114

## Summary
Adds a new "BDK Tech Talks" section to the `getting-started/more.md` page with links to all 7 talks from the official BDK YouTube channel.

## Changes
- Added BDK Tech Talks section to `docs/getting-started/more.md`
- Includes playlist link and individual video links with speaker credits

## Talks Added
| Talk | Speaker |
|------|---------|
| BDK Language Bindings | thunderbiscuit |
| BDK Silent Payments | nymius |
| Getting Your Transaction in Ordering | ValuedMammal |
| BDk-CLI | Peter Tyonum |
| Integrating Compact Block Filters in Wallets | Robert Netzke |
| BDK on Mobile | Matthew Ramsden |
| BDK at Portal | Alekos Filini |