### PR TITLE
Update starter example to use new signing workflow

### DIFF
--- a/docs/cookbook/starter-example.md
+++ b/docs/cookbook/starter-example.md
@@ -1,4 +1,4 @@
-# Simple Starter Example
+# Starter Example
 
 So you want to build a bitcoin wallet using BDK. Great! Here is the rough outline of what you need to do just that. A standard, simple example of a bitcoin wallet in BDK-land would require 3 core pillars:
 
@@ -27,10 +27,7 @@ So you want to build a bitcoin wallet using BDK. Great! Here is the rough outlin
 
 This page provides a starter example showcasing how BDK can be used to create, sync, and manage a wallet using an Esplora client as a blockchain data source. Familiarity with this example will help you work through the more advanced pages in this section.
 
-You can find [working code examples](https://github.com/bitcoindevkit/book-of-bdk/tree/master/examples) of this example in three programming languages: [Rust](https://github.com/bitcoindevkit/book-of-bdk/tree/master/examples/rust), [Swift](https://github.com/bitcoindevkit/book-of-bdk/tree/master/examples/swift), and [Kotlin](https://github.com/bitcoindevkit/book-of-bdk/tree/master/examples/kotlin). (Note: some additional language bindings are available for BDK, see [3rd Party Bindings](../getting-started/3rd-party-bindings.md)).
-
-!!!tip
-    To complete this example from top to bottom, you'll need to create new descriptors and replace the ones provided. Once you do so, you'll run the example twice; on first run the wallet will not have any balance and will exit with an address to send funds to. Once that's done, you can run the example again and the wallet will be able to perform the later steps, namely creating and broadcasting a new transaction.
+You can find [working code](https://github.com/bitcoindevkit/book-of-bdk/tree/master/examples) for this example in a multitude of programming languages: Rust, Swift, Kotlin, Python, and WASM. Note that some additional language bindings are available for BDK, namely Dart (Flutter) and React Native.
 
 ## Create a new project
 
@@ -47,16 +44,13 @@ cd starter-example
 
 ## Use descriptors
 
-To create a wallet using BDK, we need some <a href="https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md" target="_blank">descriptors</a> for our wallet. This example uses public descriptors (meaning they cannot be used to sign transactions) on Signet. Step 7 and below will fail unless you replace those public descriptors with private ones of your own and fund them using Signet coins through a faucet. Refer to the [Creating Descriptors](./keys-descriptors/descriptors.md) page for information on how to generate your own private descriptors.
-
-!!!warning
-    Note that if you replace the descriptors after running the example using the provided ones, you must delete or rename the database file or will get an error on wallet load.
+To create a wallet using BDK, we need some <a href="https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md" target="_blank">descriptors</a> for our wallet. This example uses public descriptors (meaning they cannot be used to sign transactions) to create the wallet, sync, and build transactions, and the associated private descriptors to sign the PSBT. Refer to the [Creating Descriptors](./keys-descriptors/descriptors.md) page for information on how to generate your own private descriptors.
 
 ```rust
 --8<-- "examples/rust/starter-example/src/main.rs:descriptors"
 ```
 
-These are taproot descriptors (`tr()`) using public keys on Signet (`tpub`) as described in <a href="https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki" target="_blank">BIP86</a>. The first descriptor is an HD wallet with a path for generating addresses to give out externally for payments. The second one is used by the wallet to generate addresses to pay ourselves change when sending payments (remember that <a href="https://github.com/bitcoinbook/bitcoinbook/blob/develop/ch06_transactions.adoc#outpoint" target="_blank">UTXOs</a> must be spent in full, so you often need to make change).
+These are taproot descriptors (`tr()`) using public keys on Regtest (`tpub`) as described in <a href="https://github.com/bitcoin/bips/blob/master/bip-0086.mediawiki" target="_blank">BIP86</a>. The first descriptor is an HD wallet with a path for generating addresses to give out externally for payments. The second one is used by the wallet to generate addresses to pay ourselves change when sending payments.
 
 ## Create or load a wallet
 
@@ -74,28 +68,34 @@ Now let's build an Esplora client and use it to request transaction history for 
 --8<-- "examples/rust/starter-example/src/main.rs:client"
 ```
 
-In cases where you are using new descriptors that do not have a balance yet, the example will request a new address from the wallet and print it out so you can fund the wallet. Remember that this example uses Signet coins!
+In cases where you are using new descriptors that do not have a balance yet, the example will request a new address from the wallet and print it out so you can fund the wallet. Remember that this example uses Regtest coins!
 
 ```rust title="starter-example/src/main.rs"
 --8<-- "examples/rust/starter-example/src/main.rs:address"
 ```
 
-## Send a transaction
+## Create a transaction
 
-For this step you'll need a wallet built with private keys, funded with some Signet satoshis. You can find a faucet [here](https://signet25.bublina.eu.org/) to get some coins.
+For this step you'll need a wallet funded with some Regtest satoshis.
 
-Let's prepare to send a transaction. The two core choices here are where to send the funds and how much to send. We will send funds back to the faucet return address; it's good practice to send test sats back to the faucet when you're done using them.
+Let's prepare a transaction. The three core choices here are (1) where to send the funds, (2) how much to send, (3) what fees to pay. We will send funds to a generic regtest address using a feerate of 4 satoshis per vbyte.
 
 ```rust title="starter-example/src/main.rs"
 --8<-- "examples/rust/starter-example/src/main.rs:recipient"
 ```
 
-Here we are sending 5000 sats back to the faucet (make sure the wallet has at least this much balance, or change this value).
+Here we are sending `12345` sats (make sure the wallet has at least this much balance, or change this value).
 
-Finally we are ready to build, sign, and broadcast the transaction:
+Finally we are ready to build the transaction:
 
 ```rust title="starter-example/src/main.rs"
 --8<-- "examples/rust/starter-example/src/main.rs:transaction"
 ```
 
-We can view our transaction on the [mempool.space Signet explorer](https://mempool.space/signet).
+## Sign and broadcast
+
+Now that our PSBT is ready for signing, we load up the private keys in memory and use them to sign our PSBT, and finally broadcast it using the Esplora client.
+
+```rust title="starter-example/src/main.rs"
+--8<-- "examples/rust/starter-example/src/main.rs:sign"
+```

--- a/examples/rust/starter-example/src/main.rs
+++ b/examples/rust/starter-example/src/main.rs
@@ -5,11 +5,11 @@ use bdk_esplora::esplora_client::Builder;
 use bdk_esplora::EsploraExt;
 use bdk_wallet::bitcoin::{Address, Amount, FeeRate, Network, Psbt};
 use bdk_wallet::chain::spk_client::{FullScanRequestBuilder, FullScanResponse};
+use bdk_wallet::miniscript::Descriptor;
 use bdk_wallet::rusqlite::Connection;
-#[allow(deprecated)]
-use bdk_wallet::SignOptions;
-use bdk_wallet::Wallet;
+use bdk_wallet::signer::SignersContainer;
 use bdk_wallet::{AddressInfo, KeychainKind};
+use bdk_wallet::{SignOptions, Wallet};
 use std::process::exit;
 use std::str::FromStr;
 
@@ -17,12 +17,12 @@ const STOP_GAP: usize = 20;
 const PARALLEL_REQUESTS: usize = 1;
 const DB_PATH: &str = "starter.sqlite3";
 
-#[allow(deprecated)]
 fn main() {
     println!("\nWelcome to the Book of BDK Starter Example Wallet!");
     // --8<-- [start:descriptors]
-    let descriptor: &str = "tr([12071a7c/86'/1'/0']tpubDCaLkqfh67Qr7ZuRrUNrCYQ54sMjHfsJ4yQSGb3aBr1yqt3yXpamRBUwnGSnyNnxQYu7rqeBiPfw3mjBcFNX4ky2vhjj9bDrGstkfUbLB9T/0/*)#z3x5097m";
-    let change_descriptor: &str = "tr([12071a7c/86'/1'/0']tpubDCaLkqfh67Qr7ZuRrUNrCYQ54sMjHfsJ4yQSGb3aBr1yqt3yXpamRBUwnGSnyNnxQYu7rqeBiPfw3mjBcFNX4ky2vhjj9bDrGstkfUbLB9T/1/*)#n9r4jswr";
+    // Using the "awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome" mnemonic and BIP-86
+    let descriptor: &str = "tr([5bc5d243/86'/1'/0']tpubDC72NVP1RK5qwy2QdEfWphDsUBAfBu7oiV6jEFooHP8tGQGFVUeFxhgZxuk1j6EQRJ1YsS3th2RyDgReRqCL4zqp4jtuV2z7gbiqDH2iyUS/0/*)#xh44xwsp";
+    let change_descriptor: &str = "tr([5bc5d243/86'/1'/0']tpubDC72NVP1RK5qwy2QdEfWphDsUBAfBu7oiV6jEFooHP8tGQGFVUeFxhgZxuk1j6EQRJ1YsS3th2RyDgReRqCL4zqp4jtuV2z7gbiqDH2iyUS/1/*)#hrs5mmqe";
     // --8<-- [end:descriptors]
 
     // --8<-- [start:wallet]
@@ -33,8 +33,7 @@ fn main() {
     let wallet_opt = Wallet::load()
         .descriptor(KeychainKind::External, Some(descriptor))
         .descriptor(KeychainKind::Internal, Some(change_descriptor))
-        // .extract_keys() // uncomment this line when using private descriptors
-        .check_network(Network::Signet)
+        .check_network(Network::Regtest)
         .load_wallet(&mut conn)
         .unwrap();
 
@@ -42,7 +41,7 @@ fn main() {
         loaded_wallet
     } else {
         Wallet::create(descriptor, change_descriptor)
-            .network(Network::Signet)
+            .network(Network::Regtest)
             .create_wallet(&mut conn)
             .unwrap()
     };
@@ -51,7 +50,7 @@ fn main() {
     // --8<-- [start:client]
     // Sync the wallet
     let client: esplora_client::BlockingClient =
-        Builder::new("https://blockstream.info/signet/api/").build_blocking();
+        Builder::new("http://127.0.0.1:3002").build_blocking();
 
     println!("Syncing wallet...");
     let full_scan_request: FullScanRequestBuilder<KeychainKind> = wallet.start_full_scan();
@@ -67,12 +66,12 @@ fn main() {
     // --8<-- [end:client]
 
     // --8<-- [start:address]
-    if balance.total().to_sat() < 5000 {
+    if balance.total().to_sat() < 50000 {
         println!("Your wallet does not have sufficient balance for the following steps!");
         // Reveal a new address from your external keychain
         let address: AddressInfo = wallet.reveal_next_address(KeychainKind::External);
         println!(
-            "Send Signet coins to {} (address generated at index {})",
+            "Send Regtest coins to {} (index {})",
             address.address, address.index
         );
         wallet.persist(&mut conn).expect("Cannot persist");
@@ -82,13 +81,12 @@ fn main() {
 
     // --8<-- [start:recipient]
     // Use a faucet return address
-    let faucet_address =
-        Address::from_str("tb1p4tp4l6glyr2gs94neqcpr5gha7344nfyznfkc8szkreflscsdkgqsdent4")
-            .unwrap()
-            .require_network(Network::Signet)
-            .unwrap();
+    let faucet_address = Address::from_str("bcrt1qxzh0r7mlztv3m8vxet5xxnsy9zh7j5tshh6vhp")
+        .unwrap()
+        .require_network(Network::Regtest)
+        .unwrap();
 
-    let send_amount: Amount = Amount::from_sat(1000);
+    let send_amount: Amount = Amount::from_sat(12345);
     // --8<-- [end:recipient]
 
     // --8<-- [start:transaction]
@@ -98,12 +96,40 @@ fn main() {
         .add_recipient(faucet_address.script_pubkey(), send_amount);
 
     let mut psbt: Psbt = builder.finish().unwrap();
+    // --8<-- [end:transaction]
 
-    let finalized = wallet.sign(&mut psbt, SignOptions::default()).unwrap();
-    assert!(finalized);
+    // --8<-- [start:sign]
+    // Using the "awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome" mnemonic and BIP-86
+    let private_descriptor: &str = "tr(tprv8ZgxMBicQKsPdWAHbugK2tjtVtRjKGixYVZUdL7xLHMgXZS6BFbFi1UDb1CHT25Z5PU1F9j7wGxwUiRhqz9E3nZRztikGUV6HoRDYcqPhM4/86'/1'/0'/0/*)#x627tk5a";
+    let private_change_descriptor: &str = "tr(tprv8ZgxMBicQKsPdWAHbugK2tjtVtRjKGixYVZUdL7xLHMgXZS6BFbFi1UDb1CHT25Z5PU1F9j7wGxwUiRhqz9E3nZRztikGUV6HoRDYcqPhM4/86'/1'/0'/1/*)#hw0lkry9";
+
+    let (_, external_keymap) =
+        Descriptor::parse_descriptor(wallet.secp_ctx(), private_descriptor).unwrap();
+    let (_, internal_keymap) =
+        Descriptor::parse_descriptor(wallet.secp_ctx(), private_change_descriptor).unwrap();
+    let secp = bdk_wallet::bitcoin::secp256k1::Secp256k1::new();
+
+    let external_signers_container = SignersContainer::build(
+        external_keymap,
+        wallet.public_descriptor(KeychainKind::External),
+        &secp,
+    );
+    let internal_signers_container = SignersContainer::build(
+        internal_keymap,
+        wallet.public_descriptor(KeychainKind::Internal),
+        &secp,
+    );
+
+    let signers: &[&SignersContainer; 2] =
+        &[&external_signers_container, &internal_signers_container];
+
+    let psbt_was_signed_and_finalized: bool = wallet
+        .sign_with_signers(&mut psbt, signers, SignOptions::default())
+        .unwrap();
+    assert!(psbt_was_signed_and_finalized);
 
     let tx = psbt.extract_tx().unwrap();
     client.broadcast(&tx).unwrap();
     println!("Transaction broadcast! Txid: {}", tx.compute_txid());
-    // --8<-- [end:transaction]
+    // --8<-- [end:sign]
 }


### PR DESCRIPTION
This PR updates our starter example to the new signing flow enabled by `Wallet::sign_with_signers`. It also does a pass-through on the page and cleans it up a bit, tightening the language and removing unimportant parts, as well as updating it to a Regtest setup which makes it easier to reproduce and use.

The core of the page is the new code in the example:

```rust
let mut builder = wallet.build_tx();
builder
    .fee_rate(FeeRate::from_sat_per_vb(4).unwrap())
    .add_recipient(faucet_address.script_pubkey(), send_amount);

let mut psbt: Psbt = builder.finish().unwrap();

// Using the "awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome awesome" mnemonic and BIP-86
let private_descriptor: &str = "tr(tprv8ZgxMBicQKsPdWAHbugK2tjtVtRjKGixYVZUdL7xLHMgXZS6BFbFi1UDb1CHT25Z5PU1F9j7wGxwUiRhqz9E3nZRztikGUV6HoRDYcqPhM4/86'/1'/0'/0/*)#x627tk5a";
let private_change_descriptor: &str = "tr(tprv8ZgxMBicQKsPdWAHbugK2tjtVtRjKGixYVZUdL7xLHMgXZS6BFbFi1UDb1CHT25Z5PU1F9j7wGxwUiRhqz9E3nZRztikGUV6HoRDYcqPhM4/86'/1'/0'/1/*)#hw0lkry9";

let (_, external_keymap) =
    Descriptor::parse_descriptor(wallet.secp_ctx(), private_descriptor).unwrap();
let (_, internal_keymap) =
    Descriptor::parse_descriptor(wallet.secp_ctx(), private_change_descriptor).unwrap();
let secp = bdk_wallet::bitcoin::secp256k1::Secp256k1::new();

let external_signers_container = SignersContainer::build(
    external_keymap,
    wallet.public_descriptor(KeychainKind::External),
    &secp,
);
let internal_signers_container = SignersContainer::build(
    internal_keymap,
    wallet.public_descriptor(KeychainKind::Internal),
    &secp,
);

let signers: &[&SignersContainer; 2] =
    &[&external_signers_container, &internal_signers_container];

let psbt_was_signed_and_finalized: bool = wallet
    .sign_with_signers(&mut psbt, signers, SignOptions::default())
    .unwrap();
assert!(psbt_was_signed_and_finalized);

let tx = psbt.extract_tx().unwrap();
client.broadcast(&tx).unwrap();
println!("Transaction broadcast! Txid: {}", tx.compute_txid());
```